### PR TITLE
Adding specific toggle for PVR + Option to enable scene if lights already on without time condition + keep lights off setting

### DIFF
--- a/script.service.hue/resources/language/resource.language.de_DE/strings.po
+++ b/script.service.hue/resources/language/resource.language.de_DE/strings.po
@@ -111,6 +111,10 @@ msgctxt "#30515"
 msgid "Stop Scene Enabled"
 msgstr "Stop Szene aktiviert"
 
+msgctxt "#30516"
+msgid "Enable scenes if any light already on"
+msgstr "Aktivieret szenen wenn bereits Licht an ist"
+
 msgctxt "#30521"
 msgid "[B][I]Warning: Android, RPi4 and 4K not supported[/B][/I]"
 msgstr "[B][I]Warnung: Android, RPi4 und 4K werden nicht unterstützt[/B][/I]"
@@ -444,8 +448,12 @@ msgid "Enable for music videos"
 msgstr "Aktivieren für Musik Videos"
 
 msgctxt "#30804"
-msgid "Enable for other videos (Discs and Live TV)"
-msgstr "Aktivieren für andere Videos (Discs and Live TV)"
+msgid "Enable for other videos (Discs)"
+msgstr "Aktivieren für andere Videos (Discs)"
+
+msgctxt "#30805"
+msgid "Enable for live TV"
+msgstr "Aktivieren für live TV"
 
 msgctxt "#30809"
 msgid "Saturation"

--- a/script.service.hue/resources/language/resource.language.de_DE/strings.po
+++ b/script.service.hue/resources/language/resource.language.de_DE/strings.po
@@ -112,8 +112,12 @@ msgid "Stop Scene Enabled"
 msgstr "Stop Szene aktiviert"
 
 msgctxt "#30516"
-msgid "Enable scenes if any light already on"
-msgstr "Aktivieret szenen wenn bereits Licht an ist"
+msgid "Disable time check if any light already on"
+msgstr "Deaktivieren Sie die Zeitprüfung, wenn bereits Licht leuchtet"
+
+msgctxt "#30517"
+msgid "Don't enable scene if any light is off"
+msgstr "Aktivieren Sie die Szene nicht, wenn das Licht ausgeschaltet ist"
 
 msgctxt "#30521"
 msgid "[B][I]Warning: Android, RPi4 and 4K not supported[/B][/I]"

--- a/script.service.hue/resources/language/resource.language.en_GB/strings.po
+++ b/script.service.hue/resources/language/resource.language.en_GB/strings.po
@@ -112,8 +112,12 @@ msgid "Stop Scene Enabled"
 msgstr "Stop Scene Enabled"
 
 msgctxt "#30516"
-msgid "Enable scenes if any light already on"
-msgstr "Enable scenes if any light already on"
+msgid "Disable time check if any light already on"
+msgstr "Disable time check if any light already on"
+
+msgctxt "#30517"
+msgid "Don't enable scene if any light is off"
+msgstr "Don't enable scene if any light is off"
 
 msgctxt "#30521"
 msgid "[B][I]Warning: Android, RPi4 and 4K not supported[/B][/I]"

--- a/script.service.hue/resources/language/resource.language.en_GB/strings.po
+++ b/script.service.hue/resources/language/resource.language.en_GB/strings.po
@@ -111,6 +111,10 @@ msgctxt "#30515"
 msgid "Stop Scene Enabled"
 msgstr "Stop Scene Enabled"
 
+msgctxt "#30516"
+msgid "Enable scenes if any light already on"
+msgstr "Enable scenes if any light already on"
+
 msgctxt "#30521"
 msgid "[B][I]Warning: Android, RPi4 and 4K not supported[/B][/I]"
 msgstr "[B][I]Warning: Android, RPi4 and 4K not supported[/B][/I]"
@@ -446,8 +450,12 @@ msgid "Enable for music videos"
 msgstr "Enable for music videos"
 
 msgctxt "#30804"
-msgid "Enable for other videos (Discs and Live TV)"
-msgstr "Enable for other videos (Discs and Live TV)"
+msgid "Enable for other videos (Discs)"
+msgstr "Enable for other videos (Discs)"
+
+msgctxt "#30805"
+msgid "Enable for live TV"
+msgstr "Enable for live TV"
 
 msgctxt "#30809"
 msgid "Saturation"

--- a/script.service.hue/resources/lib/KodiGroup.py
+++ b/script.service.hue/resources/lib/KodiGroup.py
@@ -231,6 +231,9 @@ class KodiGroup(xbmc.Player):
             duration = infoTag.getDuration() / 60  # returns seconds, convert to minutes
             mediaType = infoTag.getMediaType()
             fileName = infoTag.getFile()
+            if not fileName and self.isPlayingVideo():
+                fileName = self.getPlayingFile()
+
             logger.debug(
                 "InfoTag contents: duration: {}, mediaType: {}, file: {}".format(duration, mediaType, fileName))
         except AttributeError:
@@ -243,13 +246,13 @@ class KodiGroup(xbmc.Player):
                        settings_storage['video_enableMusicVideo'], 
                        settings_storage['video_enablePVR'],
                        settings_storage['video_enableOther']))
-        logger.debug("Video Activation ({}): Duration: {}, mediaType: {}".format(self.kgroupID, duration, mediaType))
-        if (duration > settings_storage['videoMinimumDuration'] and
+        logger.debug("Video Activation ({}): Duration: {}, mediaType: {}, ispvr: {}".format(self.kgroupID, duration, mediaType, fileName[0:3] == "pvr"))
+        if ((duration >= settings_storage['videoMinimumDuration'] or fileName[0:3] == "pvr") and
                 ((settings_storage['video_enableMovie'] and mediaType == "movie") or
                  (settings_storage['video_enableEpisode'] and mediaType == "episode") or
                  (settings_storage['video_enableMusicVideo'] and mediaType == "MusicVideo") or
-                 (settings_storage['video_enablePVR'] and fileName[0:3] == "pvr")) or
-                settings_storage['video_enableOther']):
+                 (settings_storage['video_enablePVR'] and fileName[0:3] == "pvr") or
+                 (settings_storage['video_enableOther'] and mediaType != "movie" and mediaType != "episode" and mediaType != "MusicVideo" and fileName[0:3] != "pvr"))):
             logger.debug("Video activation: True")
             return True
         logger.debug("Video activation: False")

--- a/script.service.hue/resources/lib/kodisettings.py
+++ b/script.service.hue/resources/lib/kodisettings.py
@@ -17,6 +17,7 @@ def read_settings():
     settings_storage['initialFlash'] = ADDON.getSettingBool("initialFlash")
     settings_storage['forceOnSunset'] = ADDON.getSettingBool("forceOnSunset")
     settings_storage['daylightDisable'] = ADDON.getSettingBool("daylightDisable")
+    settings_storage['enable_if_already_active'] = ADDON.getSettingBool("enable_if_already_active")
     cache.set("script.service.hue.daylightDisable", ADDON.getSettingBool("daylightDisable"))
 
     settings_storage['enableSchedule'] = ADDON.getSettingBool("enableSchedule")
@@ -28,6 +29,7 @@ def read_settings():
     settings_storage['video_enableMovie'] = ADDON.getSettingBool("video_Movie")
     settings_storage['video_enableMusicVideo'] = ADDON.getSettingBool("video_MusicVideo")
     settings_storage['video_enableEpisode'] = ADDON.getSettingBool("video_Episode")
+    settings_storage['video_enablePVR'] = ADDON.getSettingBool("video_PVR")
     settings_storage['video_enableOther'] = ADDON.getSettingBool("video_Other")
 
     settings_storage['ambiEnabled'] = ADDON.getSettingBool("group3_enabled")

--- a/script.service.hue/resources/lib/kodisettings.py
+++ b/script.service.hue/resources/lib/kodisettings.py
@@ -18,6 +18,7 @@ def read_settings():
     settings_storage['forceOnSunset'] = ADDON.getSettingBool("forceOnSunset")
     settings_storage['daylightDisable'] = ADDON.getSettingBool("daylightDisable")
     settings_storage['enable_if_already_active'] = ADDON.getSettingBool("enable_if_already_active")
+    settings_storage['keep_lights_off'] = ADDON.getSettingBool("keep_lights_off")
     cache.set("script.service.hue.daylightDisable", ADDON.getSettingBool("daylightDisable"))
 
     settings_storage['enableSchedule'] = ADDON.getSettingBool("enableSchedule")

--- a/script.service.hue/resources/settings.xml
+++ b/script.service.hue/resources/settings.xml
@@ -109,6 +109,7 @@
         <setting id="forceOnSunset" type="bool" label="30509" default="False" />
         <setting id="daylightDisable" type="bool" label="30508" default="False" />
         <setting id="enable_if_already_active" type="bool" label="30516" default="False" />
+        <setting id="keep_lights_off" type="bool" label="30517" default="False" />
         <setting type="sep" />
         <setting id="enableSchedule" type="bool" label="30505" default="False" />
 		<setting id="startTime" type="time" label="30506" enable="eq(-1,true)" default="18:00"/>
@@ -127,5 +128,3 @@
 		
 	</category>
 </settings>
-
-

--- a/script.service.hue/resources/settings.xml
+++ b/script.service.hue/resources/settings.xml
@@ -16,6 +16,7 @@
 <!--  GROUP SECTION  0 VIDEO-->    
     <category label="32100">
         <setting id="group0_enabled" type="bool" label="30520" default="false" />
+        <setting id="enable_if_already_active" type="bool" label="30516" default="False" />
         <!--  Group playback start setting -->
         <setting type="sep" visible="eq(-1,true)" />
         <setting id="group0_startBehavior" type="bool" label="30513"  visible="eq(-2,true)" />
@@ -44,6 +45,7 @@
         <setting id="video_MinimumDuration" type="number" label="30800" default="0" />
         <setting id="video_Movie" type="bool" label="30801" default="True" />
         <setting id="video_Episode" type="bool" label="30802" default="True" />
+        <setting id="video_PVR" type="bool" label="30805" default="True" />
         <setting id="video_MusicVideo" type="bool" label="30803" default="True" />
         <setting id="video_Other" type="bool" label="30804" default="True" />
 	</category>

--- a/script.service.hue/resources/settings.xml
+++ b/script.service.hue/resources/settings.xml
@@ -16,7 +16,6 @@
 <!--  GROUP SECTION  0 VIDEO-->    
     <category label="32100">
         <setting id="group0_enabled" type="bool" label="30520" default="false" />
-        <setting id="enable_if_already_active" type="bool" label="30516" default="False" />
         <!--  Group playback start setting -->
         <setting type="sep" visible="eq(-1,true)" />
         <setting id="group0_startBehavior" type="bool" label="30513"  visible="eq(-2,true)" />
@@ -109,6 +108,7 @@
     <category label="30511">
         <setting id="forceOnSunset" type="bool" label="30509" default="False" />
         <setting id="daylightDisable" type="bool" label="30508" default="False" />
+        <setting id="enable_if_already_active" type="bool" label="30516" default="False" />
         <setting type="sep" />
         <setting id="enableSchedule" type="bool" label="30505" default="False" />
 		<setting id="startTime" type="time" label="30506" enable="eq(-1,true)" default="18:00"/>


### PR DESCRIPTION
Hello.

I suggest this PR to the main repo.

I added a specific PVR toggle to be able to disable hue actions when using live tv but not "other" content (streaming content for example).

I added an option to activate a scene without schedule/daylight condition if any light of the scene to activate is already "on".