### PR TITLE
Tweak Hue Labs effect suspending

### DIFF
--- a/script.service.hue/resources/lib/AmbiGroup.py
+++ b/script.service.hue/resources/lib/AmbiGroup.py
@@ -263,7 +263,7 @@ class AmbiGroup(KodiGroup.KodiGroup):
             self.bridge.sensors[sensor].state(status=0)
 
     def _resumeEffects(self):
-        if not self.savedEffectSensors:
+        if not hasattr(self, 'savedEffectSensors'):
             return
 
         for sensor in self.savedEffectSensors:
@@ -309,7 +309,11 @@ class AmbiGroup(KodiGroup.KodiGroup):
                 lights.setdefault(i, set())
                 lights[i] |= sensors
 
-        if not lights:
+
+        if lights:
+            xbmc.log('[script.service.hue] Found active Hue Labs effects on lights: {}'.format(lights))
+        else:
+            xbmc.log('[script.service.hue] No active Hue Labs effects found')
             return []
 
         # Find all effect sensors that use the selected Ambilights.
@@ -318,8 +322,8 @@ class AmbiGroup(KodiGroup.KodiGroup):
         # an effect will also power on its lights.
         return set([sensor
                     for i in list(self.ambiLights.keys())
-                    for sensor in lights[i]
                     if i in lights
                     and i in self.savedLightStates
                     and self.savedLightStates[i]['state']['on']
+                    for sensor in lights[i]
                     ])

--- a/script.service.hue/resources/lib/AmbiGroup.py
+++ b/script.service.hue/resources/lib/AmbiGroup.py
@@ -124,6 +124,10 @@ class AmbiGroup(KodiGroup.KodiGroup):
         xbmc.log("[script.service.hue] In ambiGroup[{}], onPlaybackPaused()".format(self.kgroupID))
         self.state = STATE_PAUSED
         self.ambiRunning.clear()
+
+        if self.disableLabs:
+            self._resumeEffects()
+
         if self.resume_state:
             self.resumeLightState()
 


### PR DESCRIPTION
Follow-up to https://github.com/zim514/script.service.hue/pull/105

This fixes some exceptions when effects are already turned off on playback start, and also improves the logging to show which active effects were detected.

I also added back the effect resuming on pause which I saw got refactored away in https://github.com/zim514/script.service.hue/commit/eeb40fde12058a7a2d06b250ecdad8e1076f0fb9 :grinning: This is useful to me because I sometimes accidentally keep things paused for hours :sweat_smile: 