### PR TITLE
Restore Hue Labs effects after light states

### DIFF
--- a/script.service.hue/resources/lib/ambigroup.py
+++ b/script.service.hue/resources/lib/ambigroup.py
@@ -102,11 +102,11 @@ class AmbiGroup(lightgroup.LightGroup):
         AMBI_RUNNING.clear()
 
         if self.enabled:
-            if self.disable_labs:
-                self._resume_effects()
-
             if self.resume_state:
                 self._resume_light_state()
+
+            if self.disable_labs:
+                self._resume_effects()
 
     def onPlayBackPaused(self):
         # always stop ambilight even if group is disabled or it'll run forever
@@ -115,11 +115,11 @@ class AmbiGroup(lightgroup.LightGroup):
         AMBI_RUNNING.clear()
 
         if self.enabled:
-            if self.disable_labs:
-                self._resume_effects()
-
             if self.resume_state:
                 self._resume_light_state()
+
+            if self.disable_labs:
+                self._resume_effects()
 
     def _resume_light_state(self):
         xbmc.log("[script.service.hue] Resuming light state")


### PR DESCRIPTION
Enabling a Hue Labs effect will also automatically save the current
state to a scene, so sometimes there's a timing problem and the bridge
ends up storing the last color and brightness from Ambilight effects.
This will then cause problems later once the effect is disabled again,
and the scene is restored.

To avoid this we can restore the light states first, before enabling
the effect sensor and triggering the scene save.