### PR TITLE
Fix check to run Ambilights only with lights

### DIFF
--- a/script.service.hue/resources/lib/ambigroup.py
+++ b/script.service.hue/resources/lib/ambigroup.py
@@ -61,7 +61,7 @@ class AmbiGroup(lightgroup.LightGroup):
             light_ids = ADDON.getSetting(f"group{self.light_group_id}_Lights").split(",")
             index = 0
 
-            if len(light_ids) <= 0:
+            if len(light_ids) > 0:
                 for L in light_ids:
                     gamut = self._get_light_gamut(self.bridge, L)
                     light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}


### PR DESCRIPTION
I noticed Ambilights stopped working recently, and after some headscratching traced it to this change from https://github.com/zim514/script.service.hue/commit/4fb3908

I think this should be `> 0` rather than `<= 0`? :grinning: 