### PR TITLE
Avoid json error caused by 429 Too Many Requests

### DIFF
--- a/script.service.hue/resources/lib/hueconnection.py
+++ b/script.service.hue/resources/lib/hueconnection.py
@@ -193,6 +193,8 @@ class HueConnection(object):
         req = ""
         try:
             req = requests.get('https://discovery.meethue.com/')
+            if req.status_code == 429:
+                return None
             result = req.json()
         except requests.exceptions.RequestException as error:
             xbmc.log(f"[script.service.hue] Nupnp failed: {error}")


### PR DESCRIPTION
When the server returns:
  HTTP/1.1 429 Too Many Requests
Prempt the error that occurs with req.json() by checking the http.status_code.

Otherwise req.json() errors with:
  Expecting value: line 1 column 1 (char 0)

fixes #250 

it would be nice to fall back to avahi for discover though

