### PR TITLE
Add generateclientkey to user creation data

### DIFF
--- a/script.service.hue/resources/lib/hue.py
+++ b/script.service.hue/resources/lib/hue.py
@@ -248,7 +248,7 @@ class Hue(object):
         log("[SCRIPT.SERVICE.HUE] v2 _create_user: In createUser")
 
         # Prepare data for POST request
-        data = '{{"devicetype": "kodi#{}"}}'.format(getfqdn())
+        data = '{{"devicetype": "kodi#{}", "generateclientkey": true}}'.format(getfqdn())
 
         time = 0
         timeout = 90


### PR DESCRIPTION
The Hue Bridge Pro requires this additional attribute in the POST request to create a new user. Without it, the Pro bridge returns an invalid response.

Adding the property makes Bridge registration work correctly with the Hue Bridge Pro.

Close: #335