### PR TITLE
Fix service-killing HueApiError paths; restore ambilight state resume

### DIFF
--- a/script.service.hue/resources/lib/ambigroup.py
+++ b/script.service.hue/resources/lib/ambigroup.py
@@ -31,6 +31,8 @@ class AmbiGroup(lightgroup.LightGroup):
         self.capacity_error_count = 0
         self.saved_light_states = {}
         self.ambi_lights = {}
+        # Incremented on every ambi loop start; a running loop exits once its generation is stale
+        self.ambi_loop_generation = 0
 
         self.image_process = imageprocess.ImageProcess()
 
@@ -49,29 +51,40 @@ class AmbiGroup(lightgroup.LightGroup):
         self.last_media_type = self._playback_type()
         enabled = getattr(self.settings_monitor, f"group{self.light_group_id}_enabled", False)
 
-        if getattr(self.settings_monitor, f"group{self.light_group_id}_enabled", False) and self.bridge.connected:
+        # Ambilight only supports video; ignore music playback entirely
+        if self._playback_type() != VIDEO:
+            log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] onAVStarted: not video, ignoring")
+            return
+
+        if enabled and self.bridge.connected:
             self._get_lights()
         else:
             return
 
+        # No lights resolved (none configured, or they were deleted on the bridge); don't start the ambi loop
+        if not self.ambi_lights:
+            log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] onAVStarted: no ambilights available, doing nothing")
+            return
+
         log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] onPlaybackStarted. Group enabled: {enabled}, Bridge connected: {self.bridge.connected}, mediaType: {self.media_type}")
 
-
-        log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] onPlaybackStarted. media_type: {self.media_type} == playback_type: {self._playback_type()}")
-        if self.media_type == self._playback_type() and self._playback_type() == VIDEO:
-            try:
-                self.info_tag = self.getVideoInfoTag()
-            except (AttributeError, TypeError) as x:
-                log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}]: OnAV Started: Can't read infoTag")
-                reporting.process_exception(x)
-        else:
+        try:
+            self.info_tag = self.getVideoInfoTag()
+        except (AttributeError, TypeError) as x:
+            log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}]: OnAV Started: Can't read infoTag")
             self.info_tag = None
+            reporting.process_exception(x)
 
         if self.activation_check.validate():
             log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] Running Play action")
 
-            # Start the Ambi loop
-            ambi_loop_thread = Thread(target=self._ambi_loop, name="_ambi_loop", daemon=True)
+            # Save current light states so they can be restored when ambilight stops
+            if getattr(self.settings_monitor, f"group{self.light_group_id}_resume_state", False):
+                self._get_and_save_light_states()
+
+            # Start the Ambi loop. Bumping the generation makes any stale loop from a previous playback exit on its next iteration.
+            self.ambi_loop_generation += 1
+            ambi_loop_thread = Thread(target=self._ambi_loop, args=(self.ambi_loop_generation,), name="_ambi_loop", daemon=True)
             ambi_loop_thread.start()
 
     def onPlayBackStopped(self):
@@ -79,14 +92,16 @@ class AmbiGroup(lightgroup.LightGroup):
         log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}]: onPlaybackStopped")
         self.state = STATE_STOPPED
         AMBI_RUNNING.clear()
+        self._resume_all_light_states()
 
     def onPlayBackPaused(self):
         # always stop ambilight even if group is disabled or it'll run forever
         log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}]: onPlaybackPaused")
         self.state = STATE_PAUSED
         AMBI_RUNNING.clear()
+        self._resume_all_light_states()
 
-    def _ambi_loop(self):
+    def _ambi_loop(self, loop_generation):
         AMBI_RUNNING.set()
         executor = ThreadPoolExecutor(max_workers=len(self.ambi_lights) * 2)
         cap = xbmc.RenderCapture()
@@ -112,7 +127,9 @@ class AmbiGroup(lightgroup.LightGroup):
         for L in list(self.ambi_lights):
             self.ambi_lights[L].update(prev_xy=(0.0001, 0.0001))
 
-        while not self.settings_monitor.abortRequested() and AMBI_RUNNING.is_set() and self.bridge.connected:  # loop until kodi tells add-on to stop or video playing flag is unset.
+        # loop until kodi tells add-on to stop, video playing flag is unset, or a newer loop generation has started (fast pause/resume)
+        while (not self.settings_monitor.abortRequested() and AMBI_RUNNING.is_set() and self.bridge.connected
+               and loop_generation == self.ambi_loop_generation):
             try:
 
                 cap_image = cap.getImage()  # timeout to wait for OS in ms, default 1000
@@ -187,10 +204,9 @@ class AmbiGroup(lightgroup.LightGroup):
                 if exc.status_code == 429:
                     log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] _update_hue_rgb: 429: Too Many Requests. Aborting request.")
                     self.bridge_capacity_error()
-                    notification(_("Hue Service"), _("Bridge overloaded, stopping ambilight"), icon=xbmcgui.NOTIFICATION_ERROR)
                 elif exc.status_code == 404:
                     log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] Not Found")
-                    notification(header=_("Hue Service"), message=_(f"ERROR: Light not found, it may have been deleted"), icon=xbmcgui.NOTIFICATION_ERROR)
+                    notification(header=_("Hue Service"), message=_("ERROR: Light not found, it may have been deleted"), icon=xbmcgui.NOTIFICATION_ERROR)
                     AMBI_RUNNING.clear()  # shut it down
                 else:
                     AMBI_RUNNING.clear()  # shut it down
@@ -199,11 +215,15 @@ class AmbiGroup(lightgroup.LightGroup):
     def bridge_capacity_error(self):
         self.capacity_error_count = self.capacity_error_count + 1  # increment counter
         log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] Bridge capacity error count: {self.capacity_error_count}")
-        if self.capacity_error_count > 50 and self.settings_monitor.show500errors:
+        if self.capacity_error_count > 50:
+            # Too many capacity errors accumulated; stop ambilight and tell the user once
             AMBI_RUNNING.clear()  # shut it down
-            stop_showing_error = xbmcgui.Dialog().yesno(_("Hue Bridge over capacity"), _("The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."), yeslabel=_("Do not show again"), nolabel=_("Ok"))
-            if stop_showing_error:
-                ADDON.setSettingBool("show500Error", False)
+            notification(_("Hue Service"), _("Bridge overloaded, stopping ambilight"), icon=xbmcgui.NOTIFICATION_ERROR)
+            # The show500Error setting gates only the dialog, not the stop itself
+            if self.settings_monitor.show500error:
+                stop_showing_error = xbmcgui.Dialog().yesno(_("Hue Bridge over capacity"), _("The Hue Bridge is over capacity. Increase refresh rate or reduce the number of Ambilights."), yeslabel=_("Do not show again"), nolabel=_("Ok"))
+                if stop_showing_error:
+                    ADDON.setSettingBool("show500Error", False)
             self.capacity_error_count = 0
 
     @staticmethod
@@ -231,62 +251,79 @@ class AmbiGroup(lightgroup.LightGroup):
         return _("Unknown")
 
     def _get_and_save_light_states(self):
-        response = self.bridge.make_api_request('GET', 'lights')
-        if response is not None and 'data' in response:
-            states = {}
-            for light in response['data']:
-                states[light['id']] = {
-                    'on': light['on']['on'],
-                    'brightness': light['dimming']['brightness'],
-                    'color': light['color']['xy'],
-                    'color_temperature': light['color_temperature']['mirek'] if 'mirek' in light['color_temperature'] else None,
-                    'dynamics': light['dynamics']['status'],
-                    'dynamics_speed': light['dynamics']['speed'],
-                    'effects': light['effects']['status'],
-                }
-            return states
-        else:
-            log("[SCRIPT.SERVICE.HUE] Failed to get light states.")
-            return None
+        # Save the current state of the configured ambilights so they can be restored when ambilight stops
+        self.saved_light_states = {}
+        for light_id in self.ambi_lights:
+            try:
+                response = self.bridge.make_api_request('GET', f'light/{light_id}')
+            except HueApiError as exc:
+                log(f"[SCRIPT.SERVICE.HUE] _get_and_save_light_states: Light[{light_id}]: {exc}")
+                continue
+            if response is not None and 'data' in response:
+                for light in response['data']:
+                    self.saved_light_states[light['id']] = {
+                        'on': light['on']['on'],
+                        'brightness': light['dimming']['brightness'],
+                        'color': light['color']['xy'],
+                        'color_temperature': light['color_temperature']['mirek'] if 'mirek' in light.get('color_temperature', {}) else None,
+                        'effects': light['effects']['status'] if 'effects' in light else None,
+                    }
+            else:
+                log(f"[SCRIPT.SERVICE.HUE] Failed to get state for Light[{light_id}].")
 
-    def _resume_all_light_states(self, states):
-        for light_id, state in states.items():
+    def _resume_all_light_states(self):
+        # Restore the light states saved when ambilight started. Only runs when the resume setting is on and there is something to restore.
+        if not getattr(self.settings_monitor, f"group{self.light_group_id}_resume_state", False) or not self.saved_light_states:
+            return
+
+        resume_transition = getattr(self.settings_monitor, f"group{self.light_group_id}_resume_transition")
+        for light_id, state in self.saved_light_states.items():
             data = {
                 "type": "light",
                 "on": {"on": state['on']},
                 "dimming": {"brightness": state['brightness']},
                 "color": {"xy": state['color']},
-                "dynamics": {
-                    "status": state['dynamics'],
-                    "speed": state['dynamics_speed']
-                },
-                "effects": {"status": state['effects']}
+                "dynamics": {"duration": resume_transition}
             }
+            if state['effects'] is not None:
+                data["effects"] = {"status": state['effects']}
             if state['color_temperature'] is not None:
                 data["color_temperature"] = {"mirek": state['color_temperature']}
-            response = self.bridge.make_api_request('PUT', f'lights/{light_id}', json=data)
+            try:
+                response = self.bridge.make_api_request('PUT', f'light/{light_id}', json=data)
+            except HueApiError as exc:
+                log(f"[SCRIPT.SERVICE.HUE] _resume_all_light_states: Light[{light_id}]: {exc}")
+                continue
             if response is not None:
                 log(f"[SCRIPT.SERVICE.HUE] Light[{light_id}] state resumed successfully.")
             else:
                 log(f"[SCRIPT.SERVICE.HUE] Failed to resume Light[{light_id}] state.")
+        # Clear saved states so a pause followed by a stop doesn't restore twice
+        self.saved_light_states = {}
 
     def _get_lights(self):
+        # Rebuild the light list from settings on every playback start, so lights deleted from the bridge don't linger in memory
+        self.ambi_lights = {}
         index = 0
         lights = getattr(self.settings_monitor, f"group{self.light_group_id}_lights")
-        if len(lights) > 0:
-            for L in lights:
-                try:
-                    gamut = self._get_light_gamut(self.bridge, L)
-                except HueApiError as exc:
-                    if exc.status_code == 404:
-                        log(f"[SCRIPT.SERVICE.HUE] _get_lights: Light[{L}] not found or ID invalid")
-                        notification(header=_("Hue Service"), message=_(f"ERROR: Light not found, it may have been deleted"), icon=xbmcgui.NOTIFICATION_ERROR)
-                        AMBI_RUNNING.clear()
-                        ADDON.setSettingString(f"group{self.light_group_id}_Lights", "-1")
-                        ADDON.setSettingString(f"group{self.light_group_id}_LightNames", _("Not selected"))
-                        continue
-                    raise
-                light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}
-                self.ambi_lights.update(light)
-                index = index + 1
+        for L in lights:
+            if L in ("", "-1"):  # empty or cleared setting, nothing to look up
+                continue
+            try:
+                gamut = self._get_light_gamut(self.bridge, L)
+            except HueApiError as exc:
+                if exc.status_code == 404:
+                    # Light no longer exists on the bridge: clear the setting so it isn't retried every playback
+                    log(f"[SCRIPT.SERVICE.HUE] _get_lights: Light[{L}] not found or ID invalid")
+                    notification(header=_("Hue Service"), message=_("ERROR: Light not found, it may have been deleted"), icon=xbmcgui.NOTIFICATION_ERROR)
+                    ADDON.setSettingString(f"group{self.light_group_id}_Lights", "-1")
+                    ADDON.setSettingString(f"group{self.light_group_id}_LightNames", _("Not selected"))
+                else:
+                    # Bridge rejected the lookup for some other reason; don't start ambilight with a partial light list
+                    log(f"[SCRIPT.SERVICE.HUE] _get_lights: Light[{L}]: {exc}")
+                self.ambi_lights = {}
+                return
+            light = {L: {'gamut': gamut, 'prev_xy': (0, 0), "index": index}}
+            self.ambi_lights.update(light)
+            index = index + 1
         log(f"[SCRIPT.SERVICE.HUE] AmbiGroup[{self.light_group_id}] Lights: {self.ambi_lights}")

--- a/script.service.hue/resources/lib/hue.py
+++ b/script.service.hue/resources/lib/hue.py
@@ -82,6 +82,8 @@ class Hue(object):
             except requests.RequestException as x:
                 log(f"[SCRIPT.SERVICE.HUE] make_request: RequestException: {x}")
                 reporting.process_exception(x)
+            if attempt == MAX_RETRIES - 1:
+                break  # no point waiting after the last attempt
             retry_time = 2 ** attempt
             if attempt >= NOTIFICATION_THRESHOLD:
                 notification(_("Hue Service"), _("Connection failed, retrying..."), icon=xbmcgui.NOTIFICATION_WARNING)
@@ -156,21 +158,25 @@ class Hue(object):
             self.base_url = f"https://{self.settings_monitor.ip}/clip/v2/resource/"
             self.session.headers.update({'hue-application-key': self.settings_monitor.key})
 
-            self.devices = self.make_api_request("GET", "device")
-            if not isinstance(self.devices, dict):
-                log(f"[SCRIPT.SERVICE.HUE] connect: Connection error. Setting connected to False. {type(self.devices)}: {self.devices}")
-                notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
-                self.connected = False
-                return False
+            try:
+                self.devices = self.make_api_request("GET", "device")
+                if not isinstance(self.devices, dict):
+                    log(f"[SCRIPT.SERVICE.HUE] connect: Connection error. Setting connected to False. {type(self.devices)}: {self.devices}")
+                    notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
+                    self.connected = False
+                    return False
 
-            self.scene_data = self.make_api_request("GET", "scene")
+                self.scene_data = self.make_api_request("GET", "scene")
 
-            self.bridge_id = self.get_device_by_archetype(self.devices, 'bridge_v2')
-            if self._check_version():
-                self.connected = True
-                self.update_sunset()
-                log("[SCRIPT.SERVICE.HUE] connect: Connection successful")
-                return True
+                self.bridge_id = self.get_device_by_archetype(self.devices, 'bridge_v2')
+                if self._check_version():
+                    self.connected = True
+                    self.update_sunset()
+                    log("[SCRIPT.SERVICE.HUE] connect: Connection successful")
+                    return True
+            except HueApiError as exc:
+                # Bridge rejected the request (eg. 401 after a re-pair/reset); treat as a failed connection instead of crashing the service.
+                log(f"[SCRIPT.SERVICE.HUE] connect: HueApiError: {exc}")
             log("[SCRIPT.SERVICE.HUE] connect: Connection attempts failed. Setting connected to False")
             notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
             self.connected = False
@@ -178,6 +184,7 @@ class Hue(object):
 
         log("[SCRIPT.SERVICE.HUE] No bridge IP or user key provided. Bridge not configured.")
         notification(_("Hue Service"), _("Bridge not configured"), icon=xbmcgui.NOTIFICATION_ERROR)
+        self.connected = False
         return False
 
     def discover(self):
@@ -329,8 +336,20 @@ class Hue(object):
         return False
 
     def update_sunset(self):
-        geolocation = self.make_api_request("GET", "geolocation")
+        try:
+            geolocation = self.make_api_request("GET", "geolocation")
+        except HueApiError as exc:
+            log(f"[SCRIPT.SERVICE.HUE] update_sunset(): HueApiError: {exc}")
+            geolocation = None
         log(f"[SCRIPT.SERVICE.HUE] update_sunset(): geolocation: {geolocation}")
+        if geolocation is None:
+            # Request failed; keep the previous sunset if there is one so a transient outage doesn't reset it.
+            if self.sunset is not None:
+                log(f"[SCRIPT.SERVICE.HUE] update_sunset(): request failed, keeping previous sunset: {self.sunset}")
+                return
+            log("[SCRIPT.SERVICE.HUE] update_sunset(): request failed and no previous sunset, defaulting to 19:00")
+            self.sunset = convert_time("19:00")
+            return
         sunset_str = self.search_dict(geolocation, "sunset_time")
         if sunset_str is None or sunset_str == "":
             log("[SCRIPT.SERVICE.HUE] Sunset not found; configure Hue geolocalisation")
@@ -366,9 +385,18 @@ class Hue(object):
         ADDON.openSettings()
 
     def get_scenes_and_areas(self):
-        scenes_data = self.make_api_request("GET", "scene")
-        rooms_data = self.make_api_request("GET", "room")
-        zones_data = self.make_api_request("GET", "zone")
+        try:
+            scenes_data = self.make_api_request("GET", "scene")
+            rooms_data = self.make_api_request("GET", "room")
+            zones_data = self.make_api_request("GET", "zone")
+        except HueApiError as exc:
+            log(f"[SCRIPT.SERVICE.HUE] get_scenes_and_areas(): HueApiError: {exc}")
+            return None
+
+        # All three requests must have returned data before building the dictionaries
+        if not all(isinstance(d, dict) and 'data' in d for d in (scenes_data, rooms_data, zones_data)):
+            log("[SCRIPT.SERVICE.HUE] get_scenes_and_areas(): Bridge request failed, no data")
+            return None
 
         # Create dictionaries for rooms and zones
         rooms_dict = {room['id']: room['metadata']['name'] for room in rooms_data['data']}
@@ -393,7 +421,14 @@ class Hue(object):
         dialog_progress.create("Hue Service", "Searching for scenes...")
         log("[SCRIPT.SERVICE.HUE] select_hue_scene: start")
 
-        hue_scenes, hue_areas = self.get_scenes_and_areas()
+        scenes_and_areas = self.get_scenes_and_areas()
+        if scenes_and_areas is None:
+            # Bridge unreachable or rejected the request; close the progress dialog instead of leaving it stuck open
+            log("[SCRIPT.SERVICE.HUE] select_hue_scene: Can't fetch scenes from bridge")
+            dialog_progress.close()
+            notification(_("Hue Service"), _("Bridge connection failed"), icon=xbmcgui.NOTIFICATION_ERROR)
+            return None
+        hue_scenes, hue_areas = scenes_and_areas
 
         area_items = [xbmcgui.ListItem(label=name) for _, name in hue_areas.items()]
         log(f"[SCRIPT.SERVICE.HUE] select_hue_scene: area_items: {area_items}")

--- a/script.service.hue/resources/lib/lightgroup.py
+++ b/script.service.hue/resources/lib/lightgroup.py
@@ -65,12 +65,14 @@ class LightGroup(xbmc.Player):
                     self.info_tag = self.getVideoInfoTag()
                 except (AttributeError, TypeError) as x:
                     log(f"[SCRIPT.SERVICE.HUE] LightGroup[{self.light_group_id}]: OnAV Started: Can't read VideoInfoTag")
+                    self.info_tag = None
                     reporting.process_exception(x)
             elif play_enabled and self.media_type == self._playback_type() and self._playback_type() == AUDIO:
                 try:
                     self.info_tag = self.getMusicInfoTag()
                 except (AttributeError, TypeError) as x:
                     log(f"[SCRIPT.SERVICE.HUE] LightGroup[{self.light_group_id}]: OnAV Started: Can't read AudioInfoTag")
+                    self.info_tag = None
                     reporting.process_exception(x)
 
             if self.activation_check.validate(play_scene):
@@ -210,6 +212,10 @@ class ActivationChecker:
 
         # Fetch video info tag
         info_tag = self.light_group.info_tag
+        # No info tag means the current playback isn't video (or the tag couldn't be read), so video rules can't pass
+        if info_tag is None:
+            log("[SCRIPT.SERVICE.HUE] _video_activation_rules: no info tag, activation: False")
+            return False
         # Get duration in minutes
         duration = info_tag.getDuration() / 60
         # Get media type and file name
@@ -317,7 +323,19 @@ class ActivationChecker:
         all_light_states = None
         if scene and (skip_time_check_if_light_on or skip_scene_if_all_off):
             # Fetch all light states
-            all_light_states = self.light_group.bridge.make_api_request("GET", "light")
+            try:
+                all_light_states = self.light_group.bridge.make_api_request("GET", "light")
+            except HueApiError as exc:
+                log(f"[SCRIPT.SERVICE.HUE] validate: light state fetch failed: {exc}")
+                all_light_states = None
+
+            # Without light states and cached scene data the light-on shortcuts can't be evaluated; fall back to the normal schedule checks
+            scene_data = self.light_group.bridge.scene_data
+            if (not isinstance(all_light_states, dict) or 'data' not in all_light_states
+                    or not isinstance(scene_data, dict) or 'data' not in scene_data):
+                log("[SCRIPT.SERVICE.HUE] validate: light states or scene data unavailable, skipping light-state shortcuts")
+                skip_time_check_if_light_on = False
+                skip_scene_if_all_off = False
 
         if self.light_group.media_type == VIDEO and scene:
             # Check video activation rules with a Scene

--- a/script.service.hue/resources/lib/settings.py
+++ b/script.service.hue/resources/lib/settings.py
@@ -122,7 +122,7 @@ class SettingsMonitor(xbmc.Monitor):
         self.group3_saturation = ADDON.getSettingNumber("group3_Saturation")
         self.group3_capture_size = ADDON.getSettingInt("group3_CaptureSize")
         self.group3_resume_state = ADDON.getSettingBool("group3_ResumeState")
-        self.group3_resume_transition = ADDON.getSettingInt("group3_ResumeTransition") * 10  # convert seconds to multiple of 100ms
+        self.group3_resume_transition = ADDON.getSettingInt("group3_ResumeTransition") * 1000  # Hue API v2 expects milliseconds, setting is in seconds
         self.group3_update_interval = ADDON.getSettingInt("group3_Interval") / 1000
 
         if self.group3_update_interval == 0: #Never allow a 0 value for update interval


### PR DESCRIPTION
Audit follow-up fixing the crash / service-death findings (H1–H5) and the ambilight lifecycle issues (M1–M7). No new dependencies, no new translatable strings; all waits stay on `waitForAbort`.

## Crash / service-death fixes

- **`connect()` / `update_sunset()` no longer let `HueApiError` escape** (`hue.py`). A bridge returning 401 (e.g. after a re-pair/reset) or 404 used to propagate to `service.py`'s top-level handler and exit the service, or silently kill the `Timers` thread via `_run_morning()`. Both now degrade to a failed connection / kept-previous-sunset. `update_sunset()` also handles a `None` geolocation response, which previously crashed in `search_dict`.
- **`select_hue_scene()` no longer leaks a stuck progress dialog** when the bridge is unreachable: `get_scenes_and_areas()` returns `None` on failure and the caller closes the dialog and notifies.
- **`ActivationChecker.validate()` guards its API data**: a failed `GET light` or missing cached `scene_data` disables the light-on shortcut checks and falls back to the normal schedule checks instead of raising `TypeError` inside a Player callback. `_video_activation_rules()` returns `False` when there is no info tag (previously an `AttributeError` on every music start with ambilight enabled — `AmbiGroup.onAVStarted` also now ignores non-video playback outright).
- **Empty ambilight list can't crash the loop thread**: `onAVStarted` returns before spawning `_ambi_loop` when no lights resolve, so `ThreadPoolExecutor(max_workers=0)` is unreachable. `_get_lights()` rebuilds the list each start, skips empty/`-1` entries, and bails out cleanly on bridge errors instead of raising or leaving stale/partial state.

## Behavior fixes

- **`make_api_request()` retry loop** no longer sleeps (up to 64 s) after the final failed attempt.
- **`connect()` unconfigured branch** now sets `connected = False` (previously left stale).
- **Fast pause→resume can't leave two ambi loops running**: each loop carries a generation number and exits as soon as a newer loop starts, instead of both running and doubling the PUT rate into 429s.
- **`bridge_capacity_error()` typo fix**: it read `settings_monitor.show500errors` but the attribute is `show500error`, so the resulting `AttributeError` was swallowed by the executor and the 50-error capacity stop never fired. The setting now gates only the yes/no dialog (matching its name), and the "Bridge overloaded, stopping ambilight" notification fires once when ambilight actually stops rather than on every 429.
- **Light-state save/resume (`group3_ResumeState`) works again.** The save/restore methods were dead code using V1-style `lights` resources. This restores the wiring from `62afae4` (save states before the ambi loop starts, restore on stop/pause) which merge `943ff71` accidentally discarded as "superseded by upstream", adapted with V2 `light/{id}` endpoints, `HueApiError` guards, and saved-state clearing so pause→stop doesn't restore twice. `group3_ResumeTransition` is now converted to milliseconds as V2 `dynamics.duration` expects (was ×10, a V1 decisecond unit).

## Verification

- `python -m py_compile` passes on the four touched modules (no test suite in repo; `xbmc` modules can't import outside Kodi).
- `kodi-addon-checker --branch=matrix ./script.service.hue` is clean (only pre-existing forum-URL 403 warning).
- Traced both failure modes (`None` return and `HueApiError` raise) through every guarded call site: each now ends in a logged, non-fatal state.

Not fixed (documented in the audit, low severity): mDNS compression-pointer loop guard, `convert_time` edge cases, stray `]` in window-property keys, implicit `None` from `validate()`'s audio-without-scene path, duplicated `_check_*` bodies, `inspect.getmembers` log noise, `_create_user` `response[0]` assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxzUhTCtzgsw4grro8aFKP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxzUhTCtzgsw4grro8aFKP)_